### PR TITLE
Parse correct JSON result for Scheduled 

### DIFF
--- a/lib/FlightXML2REST.rb
+++ b/lib/FlightXML2REST.rb
@@ -2172,7 +2172,7 @@ class ScheduledResults
   attr_accessor :scheduledResult
   def initialize(scheduledResult = nil)
     begin
-      rawScheduledResult = JSON.parse(scheduledresult)
+      rawScheduledResult = JSON.parse(scheduledResult)
       scheduledResult = rawScheduledResult['ScheduledResult']
       @scheduledResult = ScheduledStruct.new(scheduledResult['next_offset'], [])
       scheduledResult['scheduled'].each do |scheduled|


### PR DESCRIPTION
Parser is case sensitive, this returns undefined method `[]' for nil:NilClass when nil returned from parser.
